### PR TITLE
Updating file header automatically when Temporal properties are updated.

### DIFF
--- a/MIKECore.pyproj
+++ b/MIKECore.pyproj
@@ -96,6 +96,7 @@
     <Compile Include="tests\test_dfsu_file.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="tests\test_dfs_temporal_axis.py" />
     <Compile Include="tests\test_eum.py">
       <SubType>Code</SubType>
     </Compile>

--- a/mikecore/DfsFile.py
+++ b/mikecore/DfsFile.py
@@ -1698,45 +1698,38 @@ class DfsDLLUtil():
 
         if   dataType is DfsSimpleType.Float:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_float))
-            data  = np.zeros(size, dtype=np.float32)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.Double:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_double))
-            data  = np.zeros(size, dtype=np.float64)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.Byte:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_byte))
-            data  = np.zeros(size, dtype=np.int8)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.Int:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_int32))
-            data  = np.zeros(size, dtype=np.int32)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.UInt:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_uint32))
-            data  = np.zeros(size, dtype=np.uint32)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.Short:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_uint16))
-            data  = np.zeros(size, dtype=np.uint16)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
         elif dataType is DfsSimpleType.UShort:
             datap = ctypes.cast(customBlockDataPointer, ctypes.POINTER(ctypes.c_uint16))
-            data  = np.zeros(size, dtype=np.uint16)
-            for i in range(size):
-                data[i] = datap[i];
+            # wrap numpy array around C array
+            data  = np.ctypeslib.as_array(datap,shape=(size,))
 
 
         customBlock = DfsCustomBlock(

--- a/tests/test_dfs_custom_block.py
+++ b/tests/test_dfs_custom_block.py
@@ -2,6 +2,7 @@ import unittest
 from mikecore.DfsFileFactory import DfsFileFactory
 from mikecore.DfsFile import *
 from numpy.testing import *
+from tests.test_util import *
 
 class Test_dfs_custom_block(unittest.TestCase):
 
@@ -42,3 +43,30 @@ class Test_dfs_custom_block(unittest.TestCase):
 
         dfsFile.Close()
 
+    def test_UpdateCustomBlockDataTest(self):
+
+        originalFilename = "testdata/OresundHD.dfs2";
+        filename = "testdata/testtmp/test_copy_OresundHD_cb.dfs2";
+
+        testUtil.copy_file(originalFilename, filename)
+
+        # Check initial value
+        dfsFile = DfsFileFactory.DfsGenericOpen(filename);
+        fileInfo = dfsFile.FileInfo;
+        customBlock = fileInfo.CustomBlocks[0];
+        assert_equal(10, customBlock.Values[3]);
+        dfsFile.Close();
+
+        # Modify value
+        dfsFile = DfsFileFactory.DfsGenericOpenEdit(filename);
+        fileInfo = dfsFile.FileInfo;
+        customBlock = fileInfo.CustomBlocks[0];
+        customBlock.Values[3] = 25;
+        dfsFile.Close();
+
+        # Check new value
+        dfsFile = DfsFileFactory.DfsGenericOpen(filename);
+        fileInfo = dfsFile.FileInfo;
+        customBlock = fileInfo.CustomBlocks[0];
+        assert_equal(25, customBlock.Values[3]);
+        dfsFile.Close();

--- a/tests/test_dfs_temporal_axis.py
+++ b/tests/test_dfs_temporal_axis.py
@@ -1,0 +1,52 @@
+import unittest
+from mikecore.DfsFileFactory import DfsFileFactory
+from mikecore.DfsFile import *
+from numpy.testing import *
+from shutil import copyfile
+import os, sys, stat
+
+class Test_dfs_temporal_axis(unittest.TestCase):
+
+    def test_ModifyEqCalTest(self):
+        sourcefilename = "testdata/TemporalEqCal.dfs0";
+        filename = "testdata/testtmp/test_temporal_modifyEqCal.dfs0";
+
+        copyfile(sourcefilename, filename)
+        os.chmod(filename, stat.S_IWRITE)
+
+        dfsFile = DfsFileFactory.DfsGenericOpen(filename);
+        timeAxis = dfsFile.FileInfo.TimeAxis;
+
+        assert_equal(0, timeAxis.FirstTimeStepIndex);
+        assert_equal(4, timeAxis.StartTimeOffset);
+        assert_equal(eumUnit.eumUsec, timeAxis.TimeUnit);
+        assert_equal(datetime.datetime(2010, 1, 4, 12, 34, 00), timeAxis.StartDateTime);
+        assert_equal(10, timeAxis.TimeStep);
+
+        dfsFile.Close();
+
+
+        # Update temporal axis
+        dfsFile = DfsFileFactory.DfsGenericOpenEdit(filename);
+        timeAxis = dfsFile.FileInfo.TimeAxis;
+
+        timeAxis.FirstTimeStepIndex = 3;
+        timeAxis.StartTimeOffset = 6;
+        timeAxis.StartDateTime = datetime.datetime(2009, 2, 2, 21, 43, 00);
+        timeAxis.TimeUnit = eumUnit.eumUminute;
+        timeAxis.TimeStep = 1;
+
+        dfsFile.Close();
+
+
+        # Load file from disc again, and check time axis
+        dfsFile = DfsFileFactory.DfsGenericOpen(filename);
+        timeAxis = dfsFile.FileInfo.TimeAxis;
+
+        assert_equal(3, timeAxis.FirstTimeStepIndex);
+        assert_equal(6, timeAxis.StartTimeOffset);
+        assert_equal(eumUnit.eumUminute, timeAxis.TimeUnit);
+        assert_equal(datetime.datetime(2009, 2, 2, 21, 43, 00), timeAxis.StartDateTime); 
+        assert_equal(1, timeAxis.TimeStep);
+          
+        dfsFile.Close();

--- a/tests/test_dfs_temporal_axis.py
+++ b/tests/test_dfs_temporal_axis.py
@@ -3,7 +3,7 @@ from mikecore.DfsFileFactory import DfsFileFactory
 from mikecore.DfsFile import *
 from numpy.testing import *
 from shutil import copyfile
-import os, sys, stat
+from tests.test_util import *
 
 class Test_dfs_temporal_axis(unittest.TestCase):
 
@@ -11,8 +11,7 @@ class Test_dfs_temporal_axis(unittest.TestCase):
         sourcefilename = "testdata/TemporalEqCal.dfs0";
         filename = "testdata/testtmp/test_temporal_modifyEqCal.dfs0";
 
-        copyfile(sourcefilename, filename)
-        os.chmod(filename, stat.S_IWRITE)
+        testUtil.copy_file(sourcefilename, filename)
 
         dfsFile = DfsFileFactory.DfsGenericOpen(filename);
         timeAxis = dfsFile.FileInfo.TimeAxis;

--- a/tests/test_run_all.py
+++ b/tests/test_run_all.py
@@ -2,6 +2,7 @@ import tests.test_eum
 import tests.test_projections
 import tests.test_miketools
 import tests.test_dfs_basic
+import tests.test_dfs_temporal_axis
 import tests.test_dfs_custom_block
 import tests.test_dfs_spatial_axis
 import tests.test_dfs_static_item
@@ -46,6 +47,10 @@ miketools_tests.test_Dfs0ToAscii();
 
 print("-- dfs misc --------------------------------------")
 tests.test_dfs_basic.test_error_reporting()
+
+print("-- dfs temporal axis -----------------------------")
+custom_temporal_axis = tests.test_dfs_temporal_axis.Test_dfs_temporal_axis()
+custom_temporal_axis.test_ModifyEqCalTest()
 
 print("-- dfs custom blocks -----------------------------")
 custom_block_tests = tests.test_dfs_custom_block.Test_dfs_custom_block()

--- a/tests/test_run_all.py
+++ b/tests/test_run_all.py
@@ -56,6 +56,7 @@ print("-- dfs custom blocks -----------------------------")
 custom_block_tests = tests.test_dfs_custom_block.Test_dfs_custom_block()
 custom_block_tests.test_dfs2()
 custom_block_tests.test_dfsu()
+custom_block_tests.test_UpdateCustomBlockDataTest()
 
 print("-- dfs static items ------------------------------")
 static_item_tests = tests.test_dfs_static_item.Test_dfs_static_item()


### PR DESCRIPTION
Easing modifying existing files. This could be applied also to other classes (spatial axis), but probably the temporal one is most important.

It avoids the usage of :
DfsDLLUtil.dfsSetTemporalAxis(file.headPointer, file.FileInfo.TimeAxis)

from the example in:
https://web.yammer.com/main/threads/eyJfdHlwZSI6IlRocmVhZCIsImlkIjoiMTIzMjc2OTExOTE4Mjg0OCJ9