### PR TITLE
Fix bug in MeshFile.Read

### DIFF
--- a/mikecore/MeshFile.py
+++ b/mikecore/MeshFile.py
@@ -304,7 +304,7 @@ class MeshFile:
                         if nodeNumber > 0:
                             nodesInElement[j] = nodeNumber
                     
-                    self.ElementTable.append(nodesInElement)
+                    self.ElementTable.append(nodesInElement[nodesInElement>0])
 
                     # Get element type from number of nodes
                     if len(self.ElementTable[i]) == 3:


### PR DESCRIPTION
Don't keep zeros when reading element table from a mixed mesh.

In a .mesh file with both tri and quad elements the element table can look like this: 

1011 4 **25**
1 8 7 1 2
2 7 4 1 **0**
3 2 3 9 8
...

where 25 in the first line indicates that the mesh contains one or more quad elements. A zero at the end of a line shows that this element is a tri element. 

Internally in MIKE core, the element table representation is a list of arrays with varying sizes depending on the number of nodes in each element. But without this PR the element table becomes all quad with references to non-existent node 0! 

Thanks to Benjamin Hernandez Alfaro for finding this bug!
