### PR TITLE
Dfsu spectral

### DIFF
--- a/mikecore/DfsuFile.py
+++ b/mikecore/DfsuFile.py
@@ -129,6 +129,9 @@ class DfsuFile(object):
       if (dimensions == 1):
         if (self.NumberOfLayers > 0):
           self.DfsuFileType = DfsuFileType.DfsuVerticalColumn;
+        elif (self.FileInfo.DataType == 2001 and (self.NumberOfFrequencies == numberOfElmts or self.NumberOfDirections == numberOfElmts)):
+          # Spectral Frequency-Direction (Rose-plot) geometry
+          self.DfsuFileType = DfsuFileType.DfsuSpectral0D;
         elif (self.FileInfo.DataType == 2002 and self.IsSpectral):
           # Spectral Frequency or Direction geometry
           self.DfsuFileType = DfsuFileType.DfsuSpectral1D;
@@ -139,6 +142,8 @@ class DfsuFile(object):
         if (self.FileInfo.DataType == 2001 and (self.NumberOfFrequencies*self.NumberOfDirections == numberOfElmts)):
           # Spectral Frequency-Direction (Rose-plot) geometry
           self.DfsuFileType = DfsuFileType.DfsuSpectral0D;
+        elif self.FileInfo.DataType == 2003:
+          self.DfsuFileType = DfsuFileType.DfsuSpectral2D;
         elif (self.NumberOfLayers == 0):
           self.DfsuFileType = DfsuFileType.Dfsu2D;
         elif (self.NumberOfLayers == self.NumberOfSigmaLayers):

--- a/mikecore/DfsuFile.py
+++ b/mikecore/DfsuFile.py
@@ -9,43 +9,43 @@ def CheckForNull(obj):
 
 class DfsuFileType(IntEnum):
 
+    # 1D series
+    Dfsu1D = 1,
+
     # 2D area series
-    Dfsu2D = 1,
+    Dfsu2D = 2,
 
     # 1D vertical column
-    DfsuVerticalColumn = 2,
+    DfsuVerticalColumn = 3,
 
     # 2D vertical slice through a Dfsu3DSigma
-    DfsuVerticalProfileSigma = 3,
+    DfsuVerticalProfileSigma = 4,
 
     # 2D vertical slice through a Dfsu3DSigmaZ
-    DfsuVerticalProfileSigmaZ = 4,
+    DfsuVerticalProfileSigmaZ = 5,
 
     # 3D file with sigma coordinates, i.e., a constant number of layers.
-    Dfsu3DSigma = 5,
+    Dfsu3DSigma = 6,
 
     # 3D file with sigma and Z coordinates, i.e. a varying number of layers.
-    Dfsu3DSigmaZ = 6,
+    Dfsu3DSigmaZ = 7,
 
     # 0D point series of spectral data (frequency, direction)
-    DfsuSpectral0D = 7
+    DfsuSpectral0D = 8
 
-    # 1D line series of spectral data (nodes, frequency, direction)
-    DfsuSpectral1D = 8
+    # 1D line series of spectral data (node, frequency, direction)
+    DfsuSpectral1D = 9
 
-    # 2D area series of spectral data (elements, frequency, direction)
-    DfsuSpectral2D = 9
-    
+    # 2D area series of spectral data (elmt, frequency, direction)
+    DfsuSpectral2D = 10
+
+
 class DfsuFile(object):
     """
     Class for exposing data from a dfsu file. 
-
     Use the DfsFileFactory to open an existing dfsu file.
-
     Use the DfsuBuilder to create a new dfsu file.
-
     You can read, write and append item-timesteps to the file. 
-
     The geometry can be altered, by moving the nodes, but the element connectivity can not be changed.
     """
 
@@ -55,6 +55,8 @@ class DfsuFile(object):
         self.DfsuFileType = DfsuFileType.Dfsu2D;
         self.NumberOfLayers = -1;
         self.NumberOfSigmaLayers = -1;
+        self.NumberOfFrequencies = -1;
+        self.NumberOfDirections = -1;
 
         # Static item
         self.__nodeIdItem = None;
@@ -78,6 +80,10 @@ class DfsuFile(object):
         self.ElementIds = None; # this can be null, then set default id's, starting from 1
         self.ElementType = None;
         self.ElementTable = [];
+
+        # Spectral definition
+        self.Frequencies = None;
+        self.Directions = None;
 
         if (not dfsFile is None):
             self.__Init(dfsFile)
@@ -112,19 +118,35 @@ class DfsuFile(object):
       else:
         self.NumberOfSigmaLayers = self.NumberOfLayers;
 
+      if (self.FileInfo.DataType in (2002, 2003) or (self.FileInfo.DataType == 2001 and (customBlock.Count == 6))):
+        self.NumberOfFrequencies = customBlock[4];
+        self.NumberOfDirections = customBlock[5];
+      else:
+        self.NumberOfFrequencies = 0;
+        self.NumberOfDirections = 0;
+
       # Figuring out dfsu file type from custom block MIKE_FM
       if (dimensions == 1):
-        self.DfsuFileType = DfsuFileType.DfsuVerticalColumn;
+        if (self.NumberOfLayers > 0):
+          self.DfsuFileType = DfsuFileType.DfsuVerticalColumn;
+        elif (self.FileInfo.DataType == 2001 and self.IsSpectral):
+          # Spectral Frequency or Direction geometry
+          self.DfsuFileType = DfsuFileType.DfsuSpectral1D;
+        else:
+          self.DfsuFileType = DfsuFileType.Dfsu1D;
+
       elif (dimensions == 2):
-        if (self.NumberOfLayers == 0):
+        if (self.FileInfo.DataType == 2001 and (self.NumberOfFrequencies*self.NumberOfDirections == numberOfElmts)):
+          # Spectral Frequency-Direction (Rose-plot) geometry
+          self.DfsuFileType = DfsuFileType.DfsuSpectral0D;
+        elif (self.NumberOfLayers == 0):
           self.DfsuFileType = DfsuFileType.Dfsu2D;
         elif (self.NumberOfLayers == self.NumberOfSigmaLayers):
           self.DfsuFileType = DfsuFileType.DfsuVerticalProfileSigma;
         else:
           self.DfsuFileType = DfsuFileType.DfsuVerticalProfileSigmaZ;
- 
-      elif (dimensions == 3):
 
+      elif (dimensions == 3):
         if (self.NumberOfLayers == self.NumberOfSigmaLayers):
           self.DfsuFileType = DfsuFileType.Dfsu3DSigma;
         else:
@@ -142,6 +164,9 @@ class DfsuFile(object):
           # "Element type"  , int
           # "No of nodes"   , int
           # "Connectivity"  , int
+          # For spectral files also at least one of:
+          # "Frequency"     , double
+          # "Direction"     , double
 
           self.__nodeIdItem = self.dfsFile.ReadStaticItemNext(); CheckForNull(self.__nodeIdItem);
           self.NodeIds = self.__nodeIdItem.Data
@@ -200,44 +225,19 @@ class DfsuFile(object):
               k += 1
           
           # Spectral Dfsu
-          frequency = self.dfsFile.ReadStaticItemNext() 
-          direction = self.dfsFile.ReadStaticItemNext()
-          if self.FileInfo.DataType in (2002, 2003) or ((frequency is not None) and (direction is not None)):
-            self.Frequency = frequency.Data
-            self.Direction = direction.Data
-
-            if (direction.Name != "Direction") or (frequency.Name != "Frequency"):
-              raise Exception("File is not a valid spectral dfsu file. It cannot be opened")
-
-            self.NumberOfFrequencies = len(self.Frequency) #customBlock[4]
-            self.NumberOfDirections = len(self.Direction) #customBlock[5]
-            
-            n2d = (self.NumberOfFrequencies + 1)*(self.NumberOfDirections + 1)
-            numberOfNodes = customBlock[0]
-            if (self.FileInfo.DataType == 2001): 
-              if (dimensions == 2) and (n2d == numberOfNodes):
-                # This is a point spectrum file
-                # the mesh is not a real geographical mesh, but an artificial one 
-                # made for plotting in MIKE Zero 
-                dimensions = 0
-              else: 
-                raise Exception("File is not a point spectrum dfsu file. It cannot be opened")
-
-            self.NumberOfLayers = 0
-            self.NumberOfSigmaLayers = 0
-            
-            if dimensions == 0:
-              self.DfsuFileType = DfsuFileType.DfsuSpectral0D
-            elif dimensions == 1:
-              self.DfsuFileType = DfsuFileType.DfsuSpectral1D
-            elif dimensions == 2:
-              self.DfsuFileType = DfsuFileType.DfsuSpectral2D
+          if (self.NumberOfFrequencies):
+              frequency = self.dfsFile.ReadStaticItemNext(); CheckForNull(frequency);
+              self.Frequency = frequency.Data
+          if (self.NumberOfDirections):
+              direction = self.dfsFile.ReadStaticItemNext(); CheckForNull(direction);
+              self.Direction = direction.Data
 
       self.NumberOfNodes = self.NodeIds.size; 
       self.ItemInfo = self.dfsFile.ItemInfo
 
       self.NumberOfElements = self.ElementIds.size
-      
+      #self.NumberOfNodes = self.X.size
+
       if (not build):
          # In append mode, move the file pointer to end of file
          # It was moved elsewhere when reading static data...
@@ -408,6 +408,9 @@ class DfsuFile(object):
         self.FileInfo.DeleteValueFloat = value
     DeleteValueFloat = property(__GetDeleteValueFloat, __SetDeleteValueFloat)
 
+    @property
+    def IsSpectral(self):
+      return (self.NumberOfFrequencies > 0) or (self.NumberOfDirections > 0)
 
 
     @staticmethod
@@ -480,20 +483,15 @@ class DfsuUtil:
       """
       Find element indices (zero based) of the elements being the upper-most element
       in its column.
-
       Each column is identified by matching node id numbers. For 3D elements the
       last half of the node numbers of the bottom element must match the first half
       of the node numbers in the top element. For 2D vertical elements the order of 
       the node numbers in the bottom element (last half number of nodes) are reversed 
       compared to those in the top element (first half number of nodes).
-
       To find the number of elements in each column, assuming the result
       is stored in res:
-
       For the first column it is res[0]+1.
-
       For the i'th column, it is res[i]-res[i-1].
-
       :returns: A list of element indices of top layer elements
       """
 
@@ -546,17 +544,12 @@ class DfsuUtil:
       """
       Find element indices (zero based) of the elements being the upper-most element
       in its column.
-
       This method uses the element center (x,y) coordinate, and identifies
       each column by having the same element center (x,y) coordinate.
-
       To find the number of elements in each column, assuming the result
       is stored in res:
-
       For the first column it is res[0]+1.
-
       For the i'th column, it is res[i]-res[i-1].
-
       :returns: A list of element indices of top layer elements
       """
 
@@ -623,7 +616,6 @@ class DfsuUtil:
       """
       Find the maximum number of layers, based on the indices of
       all top layer elements.
-
       Assuming that the topLayerElements comes ordered.
       """
       # the first column has top-element-index + 1 layers
@@ -639,7 +631,6 @@ class DfsuUtil:
       """
       Find the minimum number of layers, based on the indices of
       all top layer elements.
-
       Assuming that the <paramref name="topLayerElements"/> comes
       ordered.
       """
@@ -650,4 +641,3 @@ class DfsuUtil:
         if (layers < minLayers):
           minLayers = layers;
       return (minLayers);
-

--- a/mikecore/DfsuFile.py
+++ b/mikecore/DfsuFile.py
@@ -189,6 +189,11 @@ class DfsuFile(object):
             for j in range(nodesInElement):
               self.ElementTable[i][j] = connectivityArray[k];
               k += 1
+          
+          frequency = self.dfsFile.ReadStaticItemNext(); 
+          self.Frequency = None if frequency is None else frequency.Data
+          direction = self.dfsFile.ReadStaticItemNext();
+          self.Direction = None if direction is None else direction.Data
 
       self.NumberOfNodes = self.NodeIds.size; 
       self.ItemInfo = self.dfsFile.ItemInfo

--- a/mikecore/DfsuFile.py
+++ b/mikecore/DfsuFile.py
@@ -129,7 +129,7 @@ class DfsuFile(object):
       if (dimensions == 1):
         if (self.NumberOfLayers > 0):
           self.DfsuFileType = DfsuFileType.DfsuVerticalColumn;
-        elif (self.FileInfo.DataType == 2001 and self.IsSpectral):
+        elif (self.FileInfo.DataType == 2002 and self.IsSpectral):
           # Spectral Frequency or Direction geometry
           self.DfsuFileType = DfsuFileType.DfsuSpectral1D;
         else:
@@ -227,10 +227,10 @@ class DfsuFile(object):
           # Spectral Dfsu
           if (self.NumberOfFrequencies):
               frequency = self.dfsFile.ReadStaticItemNext(); CheckForNull(frequency);
-              self.Frequency = frequency.Data
+              self.Frequencies = frequency.Data
           if (self.NumberOfDirections):
               direction = self.dfsFile.ReadStaticItemNext(); CheckForNull(direction);
-              self.Direction = direction.Data
+              self.Directions = direction.Data
 
       self.NumberOfNodes = self.NodeIds.size; 
       self.ItemInfo = self.dfsFile.ItemInfo


### PR DESCRIPTION
Support reading Dfsu spectral files. There are 3 different spectral dfsu files:

* Point spectra (DataType 2001), contains a special mesh only meant for drawing in MIKE Zero
* Line spectra (DataType 2002), values stored on nodes
* Area spectra (DataType 2003), values stores on elements 

They all have two additional static items (Frequency and Direction) compared to other dfsu files. 