### PR TITLE
FileNotFoundError is more specific than Exception

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5,3.6,3.7,3.8,3.9]
+        python-version: [3.7,3.8,3.9,"3.10","3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/mikecore/DfsFile.py
+++ b/mikecore/DfsFile.py
@@ -707,7 +707,7 @@ class DfsFile:
             self.Close()
 
         if (not os.path.isfile(filename)):
-            raise Exception("File not found {}".format(filename))
+            raise FileNotFoundError("File not found {}".format(filename))
 
         # Check if trying to edit a read-only file.
         if ((mode == DfsFileMode.Edit or mode == DfsFileMode.Append) 


### PR DESCRIPTION
This error occurs every time you have a typo in a filename, so why not use the most appropriate type of exception.