### PR TITLE
Bump version number to 0.3.0

### DIFF
--- a/mikecore/__init__.py
+++ b/mikecore/__init__.py
@@ -2,7 +2,7 @@ import os
 import platform
 from pathlib import Path
 
-__version__ = "0.3.0a0"
+__version__ = "0.3.0"
 
 p = platform.architecture()
 if not "64" in p[0]:
@@ -34,4 +34,3 @@ eumDLL.libfilepath = mikebin
 eumDLL.Init()
 MzCartDLL.Init(mikebin)
 DfsDLL.Init(mikebin)
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ path = "buildUtil/build.py"
 
 [project]
 name = "mikecore"
-version = "0.3.0a0"
+version = "0.3.0"
 description = "MIKE Core contains core libraries, like DFS (Data File System), EUM and more."
 readme = "README.md"
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
We're hoping to release 0.3.0 to support the next version of MIKE IO. No new functionality in this PR, just a bumped version